### PR TITLE
Fixed incorrect error message

### DIFF
--- a/lib/service_type.js
+++ b/lib/service_type.js
@@ -105,7 +105,7 @@ ServiceType.prototype.fromJSON = function fromJSON(obj) {
 
   var service_type   = _uu(obj.name)
     , protocol       = _uu(obj.protocol)
-    , subtypes       = 'subtypes' in obj ? 
+    , subtypes       = 'subtypes' in obj ?
                         obj.subtypes.map(function(t) { return _uu(t) }) : []
     ;
 
@@ -160,7 +160,7 @@ function checkLengthAndCharset(str) {
     throw new Error('type ' + str + ' has more than 14 characters');
   }
   if (str.match(charset_regex)) {
-    throw new Error('type ' + str + ' may only contain alphanumeric ' + 
+    throw new Error('type ' + str + ' may only contain alphanumeric ' +
         'characters and hyphens');
   }
 }
@@ -171,7 +171,7 @@ function checkFormat(str) {
     throw new Error('type string must not be empty');
   }
   if (str.length > 15) {
-    throw new Error('type ' + _uu(str) + ' has more than 14 characters');
+    throw new Error('type ' + _uu(str) + ' has more than 15 characters');
   }
   if ( ! str.match(format_regex)) {
     throw new Error('type ' + str + ' must start with an underscore ' +


### PR DESCRIPTION
Service names that were too long were reported as "more than 14 characters"
when they had more than 15. I believe the correct length is max 15, so I've
changed the error text to 15. The Apple docs confirm that 15 is the right
number.

From http://developer.apple.com/library/mac/#documentation/Networking/Reference/DNSServiceDiscovery_CRef/Reference/reference.html

> The service type followed by the protocol, separated by a dot (e.g.
> "_ftp._tcp"). The service type must be an underscore, followed by 1-15
> characters, which may be letters, digits, or hyphens.
