### PR TITLE
Fixed errno usage

### DIFF
--- a/lib/resolver_sequence_tasks.js
+++ b/lib/resolver_sequence_tasks.js
@@ -106,16 +106,16 @@ try {
   _getaddrinfo = function getaddrinfo_v06x(host, family, cb) {
     var wrap = cares.getaddrinfo(host, family);
     if ( ! wrap) {
-      throw errnoException(errno, 'getaddrinfo');
+      throw errnoException(process._errno, 'getaddrinfo');
     }
     wrap.oncomplete = function(addresses) {
 
       if (addresses) {
         cb(undefined, addresses);
-      } else if (errno === 'ENOENT') {
+      } else if (process._errno === 'ENOENT') {
         cb(undefined, []);
       } else {
-        cb(errnoException(errno, 'getaddrinfo'));
+        cb(errnoException(process._errno, 'getaddrinfo'));
       }
     }
   };


### PR DESCRIPTION
Fixed the usage of errno in getaddrinfo_v06x. The browser was crashing when running on Raspberry Pi without those changes. 
