### PR TITLE
Fixes issue #72

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -28,9 +28,13 @@
             'defines': [ 'HAVE_DNSSERVICEGETADDRINFO' ]
         }]
       , ['OS=="win"', {
-            'include_dirs': [ '$(BONJOUR_SDK_HOME)Include' ]
+            'variables': {
+                'BONJOUR_SDK_DIR': '$(BONJOUR_SDK_HOME)', # Preventing path resolution problems by saving the env var in variable first 
+                'PLATFORM': '$(Platform)' # Set  the platform
+              }
+          , 'include_dirs': [ '<(BONJOUR_SDK_DIR)/Include' ]
           , 'defines': [ 'HAVE_DNSSERVICEGETADDRINFO' ]
-          , 'libraries': [ '-l$(BONJOUR_SDK_HOME)Lib/$(Platform)/dnssd.lib'
+          , 'libraries': [ '-l<(BONJOUR_SDK_DIR)/Lib/<(PLATFORM)/dnssd.lib'
                          , '-lws2_32.lib'
                          , '-liphlpapi.lib'
                          ]


### PR DESCRIPTION
Save environment variables in binding.gyp variables resolves issue with
node-gyp not being able to resolve the path right on some Windows
environments. mdns-tests are running successful. "npm install mdns"
working under Windows 8.1 x64 with Bonjour SDK from Apple installed and
using Visual Studio 2013 Professional.
