### PR TITLE
emit error instead of throw in async context

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -55,7 +55,7 @@ var Browser = exports.Browser = function Browser(serviceType, options) {
           if(typeof interfaceNames[ifaceIdx] !== "undefined") {
             service.networkInterface = interfaceNames[ifaceIdx];
           } else {
-            throw e;
+            self.emit('error', e);
           }
         }
       }


### PR DESCRIPTION
This refers to: https://github.com/agnat/node_mdns/issues/97#issuecomment-58506083

Basically, there is a `throw` in an async context, making it impossible to catch the error. Changed it to `emit`.
