### PR TITLE
upgrade nan due to failing compilation on latest nodejs versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   ]
 , "dependencies":
   { "bindings": "~1.2.1"
-  , "nan": "~1.3.0"
+  , "nan": "~1.4.0"
   }
 , "gypfile": true
 }


### PR DESCRIPTION
With nan 1.3, install failed on Travis-CI: https://travis-ci.org/j-san/mdns-recorder/builds/40232331
With nan 1.4, install works fine: https://travis-ci.org/j-san/mdns-recorder/builds/40272359
