### PR TITLE
Fix Windows 8.1 Build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -38,6 +38,7 @@
                          , '-lws2_32.lib'
                          , '-liphlpapi.lib'
                          ]
+          , 'library_dirs': ['$(WindowsSdkDir)lib/winv6.3/um/<(PLATFORM)']
         }]
       ]
     , "include_dirs": [ "<!(node -e \"require('nan')\")" ]


### PR DESCRIPTION
This PR collects changes needed to compile mdns on Windows 8.1. It's related to #113.