### PR TITLE
Emit dns error thrown by native code

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -36,9 +36,19 @@ var Browser = exports.Browser = function Browser(serviceType, options) {
         serviceType = serviceName + '.' + serviceType.split('.').shift();
         serviceName = null;
       }
+
+      var type;
+
+      try {
+        type = st.makeServiceType(serviceType);
+      } catch(e) {
+        self.emit('error', e);
+        return;
+      }
+
       var service = {
           interfaceIndex: ifaceIdx
-        , type: st.makeServiceType(serviceType)
+        , type: type
         , replyDomain: replyDomain
         , flags: flags
       };

--- a/lib/mdns_service.js
+++ b/lib/mdns_service.js
@@ -14,7 +14,11 @@ function MDNSService() {
   self.watcher.host = self; // TODO: Find out what this is for ...
   self.watcher.callback = function() {
     if (self._watcherStarted) {
-      dns_sd.DNSServiceProcessResult.call(self, self.serviceRef);  
+      try {
+        dns_sd.DNSServiceProcessResult.call(self, self.serviceRef);
+      } catch (error) {
+        self.emit("error", error);
+      }
     }
   };
 }

--- a/tests/test_mdns_service.js
+++ b/tests/test_mdns_service.js
@@ -22,7 +22,7 @@ module.exports["MDNSService"] = {
       test.done();
     });
     service.watcher.start = function() {
-      process.nextTick(this.callback.bind(null))
+      process.nextTick(this.callback.bind(null));
     }
     service.start();
   }

--- a/tests/test_mdns_service.js
+++ b/tests/test_mdns_service.js
@@ -1,0 +1,29 @@
+var dns_sd = require('../lib/dns_sd')
+  , proxyquire =  require('proxyquire')
+  ;
+
+//=== MDNSService ===========================================================
+
+module.exports["MDNSService"] = {
+  "DNS errors should propagate": function(test) {
+    var message = "Panic!"
+    var mock_dns_sd = {
+      DNSServiceProcessResult: function() {
+        throw new Error(message);
+      }
+    };
+
+    var MDNSService = proxyquire("../lib/mdns_service.js", { "./dns_sd": mock_dns_sd }).MDNSService;
+
+    var service = new MDNSService();
+    service.on("error", function(error) {
+      test.equal(message, error.message);
+
+      test.done();
+    });
+    service.watcher.start = function() {
+      process.nextTick(this.callback.bind(null))
+    }
+    service.start();
+  }
+}


### PR DESCRIPTION
The native `dns_sd.DNSServicePRocessResult` method can [throw an error](https://github.com/agnat/node_mdns/blob/7832eecc07d49f49735c771b1e00e06e513d1067/src/dns_service_process_result.cpp#L26) if there's a DNS failure, resulting in an uncaught exception and your application going down, so this pull request wraps it in a try/catch block and gets the `Browser` object (extends `MDNSService`) to emit an error event instead.

Also includes a unit test.  Actually the `test_functional`/`simple browsing` test is failing at the moment but I figure better fixed in a different commit.