### PR TITLE
Avahi probe now removes advertised HTTP service once the probe’s done.

### DIFF
--- a/lib/avahi.js
+++ b/lib/avahi.js
@@ -18,10 +18,12 @@ function supportsInterfaceIndexLocalOnly() {
           host, port, txtRec, cb, ctx);
   } catch (ex) {
     if (ex.errorCode === dns_sd.kDNSServiceErr_Unsupported) {
+      dns_sd.DNSServiceRefDeallocate(sr)
       return false;
     }
     console.warn('Unexpected result while probing for avahi:', ex);
   }
+  dns_sd.DNSServiceRefDeallocate(sr)
   return true;
 }
 

--- a/lib/avahi.js
+++ b/lib/avahi.js
@@ -18,12 +18,12 @@ function supportsInterfaceIndexLocalOnly() {
           host, port, txtRec, cb, ctx);
   } catch (ex) {
     if (ex.errorCode === dns_sd.kDNSServiceErr_Unsupported) {
-      dns_sd.DNSServiceRefDeallocate(sr)
+      dns_sd.DNSServiceRefDeallocate(sr);
       return false;
     }
     console.warn('Unexpected result while probing for avahi:', ex);
   }
-  dns_sd.DNSServiceRefDeallocate(sr)
+  dns_sd.DNSServiceRefDeallocate(sr);
   return true;
 }
 


### PR DESCRIPTION
I noticed that there was a second HTTP service being advertised on port 4321 and narrowed it down to the avahi probe ad not being removed.

(I’m assuming that there is no other purpose for keeping the avahi probe’s service ad running once the probe is complete.)