### PR TITLE
Bump nan version

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   ]
 , "dependencies":
   { "bindings": "~1.2.1"
-  , "nan": "~1.5.0"
+  , "nan": "~1.6.2"
   }
 , "gypfile": true
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   ]
 , "dependencies":
   { "bindings": "~1.2.1"
-  , "nan": "~1.6.2"
+  , "nan": "~1.7.0"
   }
 , "gypfile": true
 }


### PR DESCRIPTION
Fixes compatibility with Atom Shell 0.21.x and probably fixes #120 as they both use io.js.