### PR TITLE
Do not emit error when callback is passed to Advertisement.create

### DIFF
--- a/lib/advertisement.js
+++ b/lib/advertisement.js
@@ -40,15 +40,20 @@ function Advertisement(serviceType, port, options, callback) {
       serviceType, domain, context)
   {
     var error = dns_sd.buildException(errorCode);
-    if (callback) {
-      callback.call(self, error, {
+    var service;
+
+    if (!error) {
+      service = {
           name:    name
         , type:    makeServiceType(serviceType)
         , domain:  domain
         , flags:   flags
-      }, context);
+      };
     }
-    if (error) {
+
+    if (callback) {
+      callback(error, service, context);
+    } else if (error) {
       self.emit('error', error);
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   , "ncp":       "*"
   , "minimatch": "*"
   , "proxyquire": "~0.5"
+  , "sinon": "~1.14.1"
   }
 , "repository":
   { "type": "git"
@@ -61,4 +62,3 @@
   }
 , "gypfile": true
 }
-

--- a/tests/test_advert.js
+++ b/tests/test_advert.js
@@ -1,0 +1,71 @@
+var st = require('../lib/service_type.js')
+  , dns_sd = require('../lib/dns_sd')
+  , proxyquire =  require('proxyquire')
+  , sinon = require('sinon')
+  ;
+
+//=== Browser ===========================================================
+
+module.exports["Advertisement"] = {
+  "Should pass error to callback when error occurs during service registration": function(test) {
+    var callback = null
+      , invocations = 0
+      , threwException = false
+      , serviceType = "foo"
+      , port = "bar"
+      , options = "baz"
+      , error = new Error("Fail!")
+      , code = 10;
+
+    var mock_dns_sd = {
+      buildException: sinon.stub().withArgs(code).returns(error),
+      DNSServiceRegister: sinon.stub().callsArgWithAsync(9, null, null, code, null, null, null, null)
+    };
+
+    var mock_service_type = {
+      makeServiceType: sinon.stub()
+    }
+
+    // create the browser with our mock of dns_sd
+    var ad = proxyquire('../lib/advertisement.js', {
+      './dns_sd': mock_dns_sd,
+      './service_type': mock_service_type
+    }).Advertisement.create(serviceType, port, options, function(er) {
+      test.equal(error, er);
+
+      test.done();
+    });
+  },
+
+  "Should emit an error when when error occurs during service registration and no callbacked is passed": function(test) {
+    var callback = null
+      , invocations = 0
+      , threwException = false
+      , serviceType = "foo"
+      , port = "bar"
+      , options = "baz"
+      , error = new Error("Fail!")
+      , code = 10;
+
+    var mock_dns_sd = {
+      buildException: sinon.stub().withArgs(code).returns(error),
+      DNSServiceRegister: sinon.stub().callsArgWithAsync(9, null, null, code, null, null, null, null)
+    };
+
+    var mock_service_type = {
+      makeServiceType: sinon.stub()
+    }
+
+    // create the browser with our mock of dns_sd
+    var ad = proxyquire('../lib/advertisement.js', {
+      './dns_sd': mock_dns_sd,
+      './service_type': mock_service_type
+    }).Advertisement.create(serviceType, port, options)
+
+    ad.on('error', function(er) {
+      test.equal(error, er);
+
+      test.done();
+    });
+  }
+}


### PR DESCRIPTION
If `dns_sd.DNSServiceRegister` results in an error and you've passed a callback to `Advertisement.create` the error is passed to the callback as well as being emitted on the advert itself.

E.g.:

```javascript
var advert = mdns.createAdvertisement(mdns.tcp('my-service'), port, function (error) {
  // will be called with error
})
advert.on('error', function (error) {
  // will also be called with the same error
})
```

Since the error is emitted on the advert you have to listen for the error event even if you pass a callback otherwise your process will crash with an uncaught exception.

This pull request changes `Advertisement` to not emit the error if a callback was passed and adds tests for the new behaviour.