### PR TITLE
Add ability to update TXTRecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ In random order:
 * Ron Korving ([ronkorving](https://github.com/ronkorving))
 * Don Park ([donpark](https://github.com/donpark))
 * Cong Liu ([ghostoy](https://github.com/ghostoy))
+* Tian Zhang ([KhaosT](https://github.com/KhaosT))
 
 Your name is missing on the list? Shame on me. Please open an issue.
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -10,6 +10,7 @@
                  , 'src/dns_service_ref_sock_fd.cpp'
                  , 'src/dns_service_register.cpp'
                  , 'src/dns_service_resolve.cpp'
+                 , 'src/dns_service_update_record.cpp'
                  , 'src/mdns_utils.cpp'
                  , 'src/network_interface.cpp'
                  , 'src/socket_watcher.cpp'

--- a/lib/advertisement.js
+++ b/lib/advertisement.js
@@ -64,6 +64,16 @@ Advertisement.create = function create(serviceType, port, options, callback) {
   return new Advertisement(serviceType, port, options, callback);
 }
 
+Advertisement.prototype.updateTXTRecord = function updateTXTRecord(txtRecord) {
+  if (txtRecord && typeof txtRecord === 'object' &&
+      ! (txtRecord instanceof dns_sd.TXTRecordRef || Buffer.isBuffer(txtRecord)))
+  {
+    txtRecord = objectToTXTRecord(txtRecord);
+  }
+
+  dns_sd.DNSServiceUpdateRecord(this.serviceRef, null, 0, txtRecord, 0);
+}
+
 function objectToTXTRecord(o) {
   var record = new dns_sd.TXTRecordRef()
     , value

--- a/package.json
+++ b/package.json
@@ -57,6 +57,9 @@
   , { "name":   "Cong Liu"
     , "github": "ghostoy"
     }
+  , { "name":   "Tian Zhang"
+    , "github": "KhaosT"
+    }
   ]
 , "dependencies":
   { "bindings": "~1.2.1"

--- a/src/dns_sd.cpp
+++ b/src/dns_sd.cpp
@@ -16,6 +16,7 @@ namespace node_mdns {
 
 // === dns_sd ===========================================
 NAN_METHOD(DNSServiceRegister);
+NAN_METHOD(DNSServiceUpdateRecord);
 NAN_METHOD(DNSServiceRefSockFD);
 NAN_METHOD(DNSServiceProcessResult);
 NAN_METHOD(DNSServiceBrowse);
@@ -58,6 +59,7 @@ init(Local<Object> target) {
 #endif
 
     defineFunction(target, "DNSServiceRegister", DNSServiceRegister);
+    defineFunction(target, "DNSServiceUpdateRecord", DNSServiceUpdateRecord);
     defineFunction(target, "DNSServiceRefSockFD", DNSServiceRefSockFD);
     defineFunction(target, "DNSServiceProcessResult", DNSServiceProcessResult);
     defineFunction(target, "DNSServiceBrowse", DNSServiceBrowse);

--- a/src/dns_service_update_record.cpp
+++ b/src/dns_service_update_record.cpp
@@ -1,0 +1,73 @@
+#include "mdns.hpp"
+
+#include <limits>
+
+#ifndef WIN32 // XXX
+#include <arpa/inet.h>
+#endif
+
+#include <node_buffer.h>
+
+#include "mdns_utils.hpp"
+#include "dns_service_ref.hpp"
+#include "txt_record_ref.hpp"
+
+using namespace v8;
+using namespace node;
+
+namespace node_mdns {
+
+NAN_METHOD(DNSServiceUpdateRecord) {
+    if (argumentCountMismatch(info, 5)) {
+      return throwArgumentCountMismatchException(info, 5);
+    }
+
+    if ( ! ServiceRef::HasInstance(info[0])) {
+      return throwTypeError("argument 1 must be a DNSServiceRef (sdRef)");
+    }
+    ServiceRef * serviceRef = Nan::ObjectWrap::Unwrap<ServiceRef>(info[0]->ToObject());
+
+    if ( ! info[1]->IsNull()) {
+      return throwError("argument 2 must be zero. Custom records are not supported yet.");
+    }
+
+    if ( ! info[2]->IsInt32()) {
+      return throwError("argument 3 must be an integer (DNSServiceFlags)");
+    }
+    DNSServiceFlags flags = info[2]->ToInteger()->Int32Value();
+
+    uint16_t txtLen(0);
+    const void * txtRecord(NULL);
+    if ( ! info[3]->IsNull() && ! info[3]->IsUndefined()) {
+        if (Buffer::HasInstance(info[3])) {
+            Local<Object> bufferObject = info[3]->ToObject();
+            txtRecord = Buffer::Data(bufferObject);
+            txtLen = Buffer::Length(bufferObject);
+        } else if (TxtRecordRef::HasInstance(info[3])) {
+            TxtRecordRef * ref = Nan::ObjectWrap::Unwrap<TxtRecordRef>(info[3]->ToObject());
+            txtLen = TXTRecordGetLength( & ref->GetTxtRecordRef());
+            txtRecord = TXTRecordGetBytesPtr( & ref->GetTxtRecordRef());
+        } else {
+          return throwTypeError("argument 4 must be a buffer or a dns_sd.TXTRecordRef");
+        }
+    }
+
+    if ( ! info[4]->IsInt32()) {
+      return throwError("argument 5 must be an integer (ttl)");
+    }
+    int ttl = info[4]->ToInteger()->Int32Value();
+
+    DNSServiceErrorType error = DNSServiceUpdateRecord(
+            serviceRef->GetServiceRef(),
+            NULL,
+            flags,
+            txtLen,
+            txtRecord,
+            ttl
+        );
+    if (error != kDNSServiceErr_NoError) {
+      return throwMdnsError(error);
+    }
+}
+
+} // end of namespace node_mdns

--- a/wscript
+++ b/wscript
@@ -51,6 +51,7 @@ def build(bld):
                , 'src/dns_service_register.cpp'
                , 'src/dns_service_resolve.cpp'
                , 'src/dns_service_get_addr_info.cpp'
+               , 'src/dns_service_update_record.cpp'
                , 'src/mdns_utils.cpp'
                , 'src/network_interface.cpp'
                , 'src/txt_record_ref.cpp'


### PR DESCRIPTION
Add the ability to update mDNS Advertisement TXTRecord via DNSServiceUpdateRecord.

Currently only tested on OS X 10.10.2