### PR TITLE
Add gyp paths for FreeBSD support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -28,6 +28,10 @@
       , [ 'OS=="mac"', {
             'defines': [ 'HAVE_DNSSERVICEGETADDRINFO' ]
         }]
+      , ['OS=="freebsd"', {
+            'include_dirs': [ '/usr/local/include' ]
+          , 'libraries': [ '-L/usr/local/lib' ]
+        }]
       , ['OS=="win"', {
             'variables': {
                 'BONJOUR_SDK_DIR': '$(BONJOUR_SDK_HOME)', # Preventing path resolution problems by saving the env var in variable first 


### PR DESCRIPTION
This doesn't build on FreeBSD because FreeBSD installs package files under /usr/local.  This diff adds a conditional check for FreeBSD, which adds those paths.