### PR TITLE
Modified the README.md concerning the windows installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ var all_the_types = mdns.browseThemAll(); // all_the_types is just another brows
 
 On Linux and other systems using the avahi daemon the avahi dns_sd compat library and its header files are required.  On debianesque systems the package name is `libavahi-compat-libdnssd-dev`.  On other platforms Apple's [mDNSResponder](http://opensource.apple.com/tarballs/mDNSResponder/) is recommended. Care should be taken not to install more than one mDNS stack on a system.
 
-On Windows you are going to need Apples "Bonjour SDK for Windows". You can download it either from Apple (registration required) or various unofficial sources. Take your pick. After installing the SDK restart your shell or command prompt and make sure the `BONJOUR_SDK_HOME` environment variable is set. You'll also need a compiler. Microsoft Visual Studio Express will do. On Windows node >=0.7.9 is required.
+On Windows you are going to need Apples "Bonjour SDK for Windows". You can download it either from Apple (registration required) or various unofficial sources. Take your pick. After installing the SDK restart your computer and make sure the `BONJOUR_SDK_HOME` environment variable is set. You'll also need a compiler. Microsoft Visual Studio Express will do. On Windows node >=0.7.9 is required.
 
 mdns is available as a npm package:
 


### PR DESCRIPTION
Windows requires full restart after installing the Bonjour SDK otherwise the build will still fail.

After installing the Bonjour SDK I restarted bash and installed again. The installation behaviour was as if I hadn't installed the Bonjour SDK at all.

A full restart and trying an install again worked.