### PR TITLE
Upgrade `nan`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,70 +1,85 @@
-{ "name": "mdns"
-, "version": "2.3.4"
-, "description": "multicast DNS service discovery"
-, "main": "./lib/mdns.js"
-, "scripts":
-  { "test": "node utils/testrun"
-  }
-, "keywords": ["zeroconf", "bonjour", "dns_sd", "mDNSResponder"]
-, "devDependencies":
-  { "ejs":       "*"
-  , "less":      "*"
-  , "mkdirp":    "*"
-  , "nopt":      "*"
-  , "slide":     "*"
-  , "glob":      "*"
-  , "ncp":       "*"
-  , "minimatch": "*"
-  , "proxyquire": "^1.7.3"
-  }
-, "repository":
-  { "type": "git"
-  , "url":  "http://github.com/agnat/node_mdns.git"
-  }
-, "homepage": "http://agnat.github.com/node_mdns"
-, "bugs": { "url": "http://github.com/agnat/node_mdns/issues" }
-, "licenses": [
-    { "type": "MIT"
-    , "url": "http://github.com/agnat/node_mdns/raw/master/LICENSE"
+{
+  "name": "mdns",
+  "version": "2.3.4",
+  "description": "multicast DNS service discovery",
+  "main": "./lib/mdns.js",
+  "scripts": {
+    "test": "node utils/testrun"
+  },
+  "keywords": [
+    "zeroconf",
+    "bonjour",
+    "dns_sd",
+    "mDNSResponder"
+  ],
+  "devDependencies": {
+    "ejs": "*",
+    "less": "*",
+    "mkdirp": "*",
+    "nopt": "*",
+    "slide": "*",
+    "glob": "*",
+    "ncp": "*",
+    "minimatch": "*",
+    "proxyquire": "^1.7.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/agnat/node_mdns.git"
+  },
+  "homepage": "http://agnat.github.com/node_mdns",
+  "bugs": {
+    "url": "http://github.com/agnat/node_mdns/issues"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://github.com/agnat/node_mdns/raw/master/LICENSE"
     }
-  ]
-, "author":
-  { "name":   "David Siegel"
-  , "email":  "agnat@me.com"
-  , "github": "agnat"
-  }
-, "contributors": [
-    { "name":   "Orlando Vazquez"
-    , "email":  "ovazquez@gmail.com"
-    , "url":    "http://or.lan.do/"
-    , "github": "orlandov"
+  ],
+  "author": {
+    "name": "David Siegel",
+    "email": "agnat@me.com",
+    "github": "agnat"
+  },
+  "contributors": [
+    {
+      "name": "Orlando Vazquez",
+      "email": "ovazquez@gmail.com",
+      "url": "http://or.lan.do/",
+      "github": "orlandov"
+    },
+    {
+      "name": "Ryan Dahl",
+      "email": "ry at tiny clouds dot org",
+      "url": "http://four.livejournal.com/",
+      "github": "ry"
+    },
+    {
+      "name": "Dominic Tarr",
+      "url": "http://twitter.com/dominictarr",
+      "github": "dominictarr"
+    },
+    {
+      "name": "Emil Stenqvist",
+      "github": "emilisto"
+    },
+    {
+      "name": "Toby Ealden",
+      "github": "TobyEalden"
+    },
+    {
+      "name": "Cong Liu",
+      "github": "ghostoy"
+    },
+    {
+      "name": "Tian Zhang",
+      "github": "KhaosT"
     }
-  , { "name":   "Ryan Dahl"
-    , "email":  "ry at tiny clouds dot org"
-    , "url":    "http://four.livejournal.com/"
-    , "github": "ry"
-    }
-  , { "name":   "Dominic Tarr"
-    , "url":    "http://twitter.com/dominictarr"
-    , "github": "dominictarr"
-    }
-  , { "name":   "Emil Stenqvist"
-    , "github": "emilisto"
-    }
-  , { "name":   "Toby Ealden"
-    , "github": "TobyEalden"
-    }
-  , { "name":   "Cong Liu"
-    , "github": "ghostoy"
-    }
-  , { "name":   "Tian Zhang"
-    , "github": "KhaosT"
-    }
-  ]
-, "dependencies":
-  { "bindings": "~1.2.1"
-  , "nan": "~2.3.0"
-  }
-, "gypfile": true
+  ],
+  "dependencies": {
+    "bindings": "~1.2.1",
+    "nan": "^2.10.0"
+  },
+  "gypfile": true
 }
-


### PR DESCRIPTION
The main fix is below.
"nan": "~2.3.0" ->
"nan": "^2.10.0"

The other differences are due to formatting of npm.

* Upgrading will reduce warning.
* `Nan :: MakeCallback` warnings will continue. I will fix it after this PR.