### PR TITLE
Change `Nan::MakeCallback` to `AsyncResource::runInAsyncScope

### DIFF
--- a/src/dns_service_browse.cpp
+++ b/src/dns_service_browse.cpp
@@ -9,6 +9,8 @@ using namespace node;
 
 namespace node_mdns {
 
+static Nan::AsyncResource* asyncResource;
+
 static
 void
 DNSSD_API
@@ -36,7 +38,9 @@ OnServiceChanged(DNSServiceRef sdRef, DNSServiceFlags flags,
     } else {
         info[7] = serviceRef->GetContext();
     }
-    Nan::MakeCallback(this_, callback, argc, info);
+    asyncResource = new Nan::AsyncResource("node_mdns::DNSServiceBrowse");
+    asyncResource->runInAsyncScope(this_, callback, argc, info);
+    delete asyncResource;
 }
 
 NAN_METHOD(DNSServiceBrowse) { 

--- a/src/dns_service_enumerate_domains.cpp
+++ b/src/dns_service_enumerate_domains.cpp
@@ -8,6 +8,8 @@ using namespace node;
 
 namespace node_mdns {
 
+static Nan::AsyncResource* asyncResource;
+
 void
 DNSSD_API
 OnEnumeration(DNSServiceRef sdRef, DNSServiceFlags flags, uint32_t interfaceIndex,
@@ -26,7 +28,9 @@ OnEnumeration(DNSServiceRef sdRef, DNSServiceFlags flags, uint32_t interfaceInde
     info[3] = Nan::New<Integer>(errorCode);
     info[4] = stringOrUndefined(replyDomain);
     info[5] = serviceRef->GetContext();
-    Nan::MakeCallback(this_, callback, argc, info);
+    asyncResource = new Nan::AsyncResource("node_mdns::DNSServiceEnumerateDomains");
+    asyncResource->runInAsyncScope(this_, callback, argc, info);
+    delete asyncResource;
 }
 
 NAN_METHOD(DNSServiceEnumerateDomains) {

--- a/src/dns_service_get_addr_info.cpp
+++ b/src/dns_service_get_addr_info.cpp
@@ -18,6 +18,8 @@ namespace node_mdns {
 
 #ifdef HAVE_DNSSERVICEGETADDRINFO
 
+static Nan::AsyncResource* asyncResource;
+
 void
 DNSSD_API
 OnAddressInfo(DNSServiceRef sdRef, DNSServiceFlags flags, 
@@ -65,7 +67,9 @@ OnAddressInfo(DNSServiceRef sdRef, DNSServiceFlags flags,
     } else {
         info[7] = serviceRef->GetContext();
     }
-    Nan::MakeCallback(this_, callback, argc, info);
+    asyncResource = new Nan::AsyncResource("node_mdns::DNSServiceGetAddrInfo");
+    asyncResource->runInAsyncScope(this_, callback, argc, info);
+    delete asyncResource;
 }
 
 NAN_METHOD(DNSServiceGetAddrInfo) {

--- a/src/dns_service_register.cpp
+++ b/src/dns_service_register.cpp
@@ -17,6 +17,8 @@ using namespace node;
 
 namespace node_mdns {
 
+static Nan::AsyncResource* asyncResource;
+
 static
 void
 DNSSD_API
@@ -45,7 +47,9 @@ OnServiceRegistered(DNSServiceRef sdRef, DNSServiceFlags flags,
         } else {
             info[6] = serviceRef->GetContext();
         }
-        Nan::MakeCallback(this_, callback, argc, info);
+        asyncResource = new Nan::AsyncResource("node_mdns::DNSServiceRegister");
+        asyncResource->runInAsyncScope(this_, callback, argc, info);
+        delete asyncResource;
     }
 }
 

--- a/src/dns_service_resolve.cpp
+++ b/src/dns_service_resolve.cpp
@@ -18,6 +18,8 @@ using namespace node;
 
 namespace node_mdns {
 
+static Nan::AsyncResource* asyncResource;
+
 void
 DNSSD_API
 OnResolve(DNSServiceRef sdRef, DNSServiceFlags flags,
@@ -48,7 +50,9 @@ OnResolve(DNSServiceRef sdRef, DNSServiceFlags flags,
     } else {
         info[8] = serviceRef->GetContext();
     }
-    Nan::MakeCallback(this_, callback, argc, info);
+    asyncResource = new Nan::AsyncResource("node_mdns::DNSServiceResolve");
+    asyncResource->runInAsyncScope(this_, callback, argc, info);
+    delete asyncResource;
 }
 
 NAN_METHOD(DNSServiceResolve) {

--- a/src/socket_watcher.cpp
+++ b/src/socket_watcher.cpp
@@ -39,6 +39,8 @@ MakeCallback(const Handle<Object> object, const Handle<Function> callback,
 
 namespace node_mdns {
 
+    static Nan::AsyncResource* asyncResource;
+
     SocketWatcher::SocketWatcher() : poll_(NULL), fd_(0), events_(0) {
     }
 
@@ -97,7 +99,9 @@ namespace node_mdns {
         argv[0] = revents & UV_READABLE ? Nan::True() : Nan::False();
         argv[1] = revents & UV_WRITABLE ? Nan::True() : Nan::False();
 
-        Nan::MakeCallback(watcher->handle(), callback, 2, argv);
+        asyncResource = new Nan::AsyncResource("node_mdns::SocketWatcher");
+        asyncResource->runInAsyncScope(watcher->handle(), callback, 2, argv);
+        delete asyncResource;
     }
 
     NAN_METHOD(SocketWatcher::Stop) {


### PR DESCRIPTION
The following warning:
```
warning: ‘v8::Local<v8::Value> Nan::MakeCallback(v8::Local<v8::Object>,
v8::Local<v8::Function>, int, v8::Local<v8::Value>*)’ is deprecated
[-Wdeprecated-declarations]
         Nan::MakeCallback(this_, callback, argc, info);
```