### PR TITLE
Replace `v8::String::Utf8Value` with `Nan::Utf8String`

### DIFF
--- a/src/demangle.cpp
+++ b/src/demangle.cpp
@@ -11,7 +11,7 @@ namespace {
 Handle<Value>
 demangle(Arguments const& info) {
     Nan::HandleScope scope;  
-    String::Utf8Value str(info[0]->ToString());
+    Nan::Utf8String str(info[0]->ToString());
 #ifdef __GNUC__
     int status;
     char * ret = abi::__cxa_demangle(*str, NULL, NULL, & status);

--- a/src/dns_service_browse.cpp
+++ b/src/dns_service_browse.cpp
@@ -65,7 +65,7 @@ NAN_METHOD(DNSServiceBrowse) {
     if ( ! info[3]->IsString()) {
         return throwTypeError("argument 4 must be a string (service type)");
     }
-    String::Utf8Value serviceType(info[3]->ToString());
+    Nan::Utf8String serviceType(info[3]->ToString());
 
     bool has_domain = false;
     if ( ! info[4]->IsNull() && ! info[4]->IsUndefined()) {
@@ -74,7 +74,7 @@ NAN_METHOD(DNSServiceBrowse) {
         }
         has_domain = true;
     }
-    String::Utf8Value domain(info[4]);
+    Nan::Utf8String domain(info[4]);
 
     if ( ! info[5]->IsFunction()) {
         return throwTypeError("argument 6 must be a function (callBack)");

--- a/src/dns_service_get_addr_info.cpp
+++ b/src/dns_service_get_addr_info.cpp
@@ -100,7 +100,7 @@ NAN_METHOD(DNSServiceGetAddrInfo) {
     if ( ! info[4]->IsString()) {
         return throwTypeError("argument 5 must be a string (hostname)");
     }
-    String::Utf8Value hostname(info[4]->ToString());
+    Nan::Utf8String hostname(info[4]->ToString());
 
     if ( ! info[5]->IsFunction()) {
         return throwTypeError("argument 6 must be a function (callBack)");

--- a/src/dns_service_register.cpp
+++ b/src/dns_service_register.cpp
@@ -79,12 +79,12 @@ NAN_METHOD(DNSServiceRegister) {
         }
         has_name = true;
     }
-    String::Utf8Value name(info[3]);
+    Nan::Utf8String name(info[3]);
 
     if ( ! info[4]->IsString()) {
       return throwTypeError("argument 5 must be a string (service type)");
     }
-    String::Utf8Value serviceType(info[4]->ToString());
+    Nan::Utf8String serviceType(info[4]->ToString());
 
     bool has_domain = false;
     if ( ! info[5]->IsNull() && ! info[5]->IsUndefined()) {
@@ -93,7 +93,7 @@ NAN_METHOD(DNSServiceRegister) {
         }
         has_domain = true;
     }
-    String::Utf8Value domain(info[5]);
+    Nan::Utf8String domain(info[5]);
 
     bool has_host = false;
     if ( ! info[6]->IsNull() && ! info[6]->IsUndefined()) {
@@ -102,7 +102,7 @@ NAN_METHOD(DNSServiceRegister) {
         }
         has_host = true;
     }
-    String::Utf8Value host(info[6]);
+    Nan::Utf8String host(info[6]);
 
     if ( ! info[7]->IsInt32()) {
       return throwTypeError("argument 8 must be an integer (port)");

--- a/src/dns_service_resolve.cpp
+++ b/src/dns_service_resolve.cpp
@@ -78,17 +78,17 @@ NAN_METHOD(DNSServiceResolve) {
     if ( ! info[3]->IsString()) {
         return throwTypeError("argument 4 must be a string (name)");
     }
-    String::Utf8Value name(info[3]->ToString());
+    Nan::Utf8String name(info[3]->ToString());
 
     if ( ! info[4]->IsString()) {
         return throwTypeError("argument 5 must be a string (service type)");
     }
-    String::Utf8Value serviceType(info[4]->ToString());
+    Nan::Utf8String serviceType(info[4]->ToString());
 
     if ( ! info[5]->IsString()) {
         return throwTypeError("argument 6 must be a string (domain)");
     }
-    String::Utf8Value domain(info[5]->ToString());
+    Nan::Utf8String domain(info[5]->ToString());
 
     if ( ! info[6]->IsFunction()) {
         return throwTypeError("argument 7 must be a function (callBack)");

--- a/src/network_interface.cpp
+++ b/src/network_interface.cpp
@@ -28,7 +28,7 @@ NAN_METHOD(if_nametoindex) {
     if ( ! info[0]->IsString()) {
         return throwTypeError("argument 1 must be a string (interface name)");
     }
-    String::Utf8Value interfaceName(info[0]->ToString());
+    Nan::Utf8String interfaceName(info[0]->ToString());
 
 #ifdef WIN32
     DWORD aliasLength = MultiByteToWideChar(CP_UTF8, 0, *interfaceName, -1,

--- a/src/txt_record_set_value.cpp
+++ b/src/txt_record_set_value.cpp
@@ -32,7 +32,7 @@ NAN_METHOD(TXTRecordSetValue) {
     if ( ! info[1]->IsString()) {
         return throwTypeError("argument 1 must be a string (key)");
     }
-    String::Utf8Value key(info[1]);
+    Nan::Utf8String key(info[1]);
     
     if ( ! (info[2]->IsNull() || info[2]->IsUndefined() ||
         Buffer::HasInstance(info[2]) || info[2]->IsString())) {
@@ -41,7 +41,7 @@ NAN_METHOD(TXTRecordSetValue) {
     DNSServiceErrorType code = TXTRecordSetValue( & ref->GetTxtRecordRef(), *key,
             length(info[2]),
             ((info[2]->IsNull()||info[2]->IsUndefined()) 
-                ? NULL : info[2]->IsString() ? *String::Utf8Value(info[2]->ToString()) : Buffer::Data(info[2]->ToObject())));
+                ? NULL : info[2]->IsString() ? *Nan::Utf8String(info[2]->ToString()) : Buffer::Data(info[2]->ToObject())));
 
     if (code != kDNSServiceErr_NoError) {
         return throwMdnsError(code);


### PR DESCRIPTION
The following warning at Node.js 10.

```
‘v8::String::Utf8Value::Utf8Value(v8::Local<v8::Value>)’ is deprecated:
Use Isolate version [-Wdeprecated-declarations]
   v8::String::Utf8Value command(optionsToCommandString(info));
```