### PR TITLE
Include version-dependent error codes when available

### DIFF
--- a/src/dns_sd.cpp
+++ b/src/dns_sd.cpp
@@ -137,29 +137,32 @@ addConstants(Local<Object> target) {
     NODE_DEFINE_CONSTANT(target, kDNSServiceErr_NATTraversal);
     NODE_DEFINE_CONSTANT(target, kDNSServiceErr_DoubleNAT);
     NODE_DEFINE_CONSTANT(target, kDNSServiceErr_BadTime);
-#ifdef kDNSServiceErr_BadSig
+#if defined(kDNSServiceErr_BadSig) || _DNS_SD_H >= 1610100
     NODE_DEFINE_CONSTANT(target, kDNSServiceErr_BadSig);
 #endif
-#ifdef kDNSServiceErr_BadKey
+#if defined(kDNSServiceErr_BadKey) || _DNS_SD_H >= 1610100
     NODE_DEFINE_CONSTANT(target, kDNSServiceErr_BadKey);
 #endif
-#ifdef kDNSServiceErr_Transient
+#if defined(kDNSServiceErr_Transient) || _DNS_SD_H >= 1610100
     NODE_DEFINE_CONSTANT(target, kDNSServiceErr_Transient);
 #endif
-#ifdef kDNSServiceErr_ServiceNotRunning
+#if defined(kDNSServiceErr_ServiceNotRunning) || _DNS_SD_H >= 1610100
     NODE_DEFINE_CONSTANT(target, kDNSServiceErr_ServiceNotRunning);
 #endif
-#ifdef kDNSServiceErr_NATPortMappingUnsupported
+#if defined(kDNSServiceErr_NATPortMappingUnsupported) || _DNS_SD_H >= 1610100
     NODE_DEFINE_CONSTANT(target, kDNSServiceErr_NATPortMappingUnsupported);
 #endif
-#ifdef kDNSServiceErr_NATPortMappingDisabled
+#if defined(kDNSServiceErr_NATPortMappingDisabled) || _DNS_SD_H >= 1610100
     NODE_DEFINE_CONSTANT(target, kDNSServiceErr_NATPortMappingDisabled);
 #endif
-#ifdef kDNSServiceErr_NoRouter
+#if defined(kDNSServiceErr_NoRouter) || _DNS_SD_H >= 1710400
     NODE_DEFINE_CONSTANT(target, kDNSServiceErr_NoRouter);
 #endif
-#ifdef kDNSServiceErr_PollingMode
+#if defined(kDNSServiceErr_PollingMode) || _DNS_SD_H >= 1710400
     NODE_DEFINE_CONSTANT(target, kDNSServiceErr_PollingMode);
+#endif
+#if defined(kDNSServiceErr_Timeout) || _DNS_SD_H >= 3200500
+    NODE_DEFINE_CONSTANT(target, kDNSServiceErr_Timeout);
 #endif
 
     // Interface Index

--- a/src/mdns_utils.cpp
+++ b/src/mdns_utils.cpp
@@ -72,39 +72,39 @@ errorString(DNSServiceErrorType error) {
             return "double NAT";
         case kDNSServiceErr_BadTime:
             return "bad time";
-#ifdef kDNSServiceErr_BadSig
+#if defined(kDNSServiceErr_BadSig) || _DNS_SD_H >= 1610100
         case kDNSServiceErr_BadSig:
             return "bad sig";
 #endif
-#ifdef kDNSServiceErr_BadKey
+#if defined(kDNSServiceErr_BadKey) || _DNS_SD_H >= 1610100
         case kDNSServiceErr_BadKey:
             return "bad key";
 #endif
-#ifdef kDNSServiceErr_Transient
+#if defined(kDNSServiceErr_Transient) || _DNS_SD_H >= 1610100
         case kDNSServiceErr_Transient:
             return "transient";
 #endif
-#ifdef kDNSServiceErr_ServiceNotRunning
+#if defined(kDNSServiceErr_ServiceNotRunning) || _DNS_SD_H >= 1610100
         case kDNSServiceErr_ServiceNotRunning:
             return "service not running";
 #endif
-#ifdef kDNSServiceErr_NATPortMappingUnsupported
+#if defined(kDNSServiceErr_NATPortMappingUnsupported) || _DNS_SD_H >= 1610100
         case kDNSServiceErr_NATPortMappingUnsupported:
             return "NAT port mapping unsupported";
 #endif
-#ifdef kDNSServiceErr_NATPortMappingDisabled
+#if defined(kDNSServiceErr_NATPortMappingDisabled) || _DNS_SD_H >= 1610100
         case kDNSServiceErr_NATPortMappingDisabled:
             return "NAT port mapping disabled";
 #endif
-#ifdef kDNSServiceErr_NoRouter
+#if defined(kDNSServiceErr_NoRouter) || _DNS_SD_H >= 1710400
         case kDNSServiceErr_NoRouter:
             return "no router";
 #endif
-#ifdef kDNSServiceErr_PollingMode
+#if defined(kDNSServiceErr_PollingMode) || _DNS_SD_H >= 1710400
         case kDNSServiceErr_PollingMode:
             return "polling mode";
 #endif
-#ifdef kDNSServiceErr_Timeout
+#if defined(kDNSServiceErr_Timeout) || _DNS_SD_H >= 3200500
         case kDNSServiceErr_Timeout:
             return "timeout";
 #endif


### PR DESCRIPTION
(I just started using node_mdns in a project that needs to run on macOS, Windows, and Linux. As expected, everything worked fine on macOS, but on Windows I found a couple of improvements, this is the first of them. I have not started on Linux yet, so more may come later.)

Some of the error code constants in the dns_sd API only appeared in certain versions. There are provisions in the node_mdns code to include these and their descriptions when they are available, however they don’t actually work, so that these codes are always omitted, resulting in exceptions with an unhelpful “dns service error: unknown error code” in the JavaScript API.

`#ifdef` is used to check for availability of the constants, however in all versions of *dns_sd.h* I have seen (Apple’s and Avahi’s) they are not defined using `#define` but using `enum`. There is no way that I know of to check for existence of an enum at preprocessing time, however Apple’s version of the header includes an API versioning define that can be used instead. I left the `#ifdef` check there in addition, in case there are versions of *dns_sd.h* where that works.

The corresponding API versions were looked up from https://github.com/Apple-FOSS-Mirror/mDNSResponder, which is more convenient than the original source https://opensource.apple.com/source/mDNSResponder/, on the unverified assumption that it is a correct mirror.