### PR TITLE
Fix exception from require('mdns') if Avahi detection fails unexpectedly

### DIFF
--- a/lib/avahi.js
+++ b/lib/avahi.js
@@ -25,7 +25,9 @@ function supportsInterfaceIndexLocalOnly() {
     }
     console.warn('Unexpected result while probing for avahi:', ex);
   }
-  dns_sd.DNSServiceRefDeallocate(sr);
+  if (sr && sr.initialized) {
+    dns_sd.DNSServiceRefDeallocate(sr);
+  }
   return true;
 }
 


### PR DESCRIPTION
When Avahi detection fails with an unexpected error such as `kDNSServiceErr_ServiceNotRunning`, it throws an exception “DNSServiceRef is not initialized” that makes it impossible to `require('mdns')`. The attached commit fixes that. `mdns.isAvahi` will simply be false then and the warning about the unexpected error is still printed to the console.