### PR TITLE
Add option to disable looking up interface names

### DIFF
--- a/doc/pages/user_guide.ejs
+++ b/doc/pages/user_guide.ejs
@@ -294,12 +294,13 @@ h4. new mdns.Browser(serviceType, [options])
 
 Create a new browser to discover services that match the given @serviceType@. @options@ may contain the following properties:
 
-- resolverSequence := custom "resolver sequence":#resolver_sequence for this browser
-- interfaceIndex   := one-based index of the network interface the services should be discovered on. *Deprecated:* Use networkInterface instead.
-- networkInterface := the network interface to use. See "Network Interfaces":#network_interfaces for details.
-- domain           := see documentation of @DNSServiceBrowse(...)@
-- context          := see documentation of @DNSServiceBrowse(...)@
-- flags            := see documentation of @DNSServiceBrowse(...)@
+- resolverSequence     := custom "resolver sequence":#resolver_sequence for this browser
+- interfaceIndex       := one-based index of the network interface the services should be discovered on. *Deprecated:* Use networkInterface instead.
+- networkInterface     := the network interface to use. See "Network Interfaces":#network_interfaces for details.
+- lookupInterfaceNames := when false the interface name will not be resolved.
+- domain               := see documentation of @DNSServiceBrowse(...)@
+- context              := see documentation of @DNSServiceBrowse(...)@
+- flags                := see documentation of @DNSServiceBrowse(...)@
 
 h4. Event: 'serviceUp'
 

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -54,18 +54,20 @@ var Browser = exports.Browser = function Browser(serviceType, options) {
       };
       if (serviceName) service.name    = serviceName;
 
-      if (dns_sd.kDNSServiceInterfaceIndexLocalOnly === ifaceIdx) {
-        service.networkInterface = nif.loopbackName();
-      } else if (typeof dns_sd.if_indextoname !== 'undefined' && ifaceIdx > 0) {
-        try {
-          service.networkInterface = dns_sd.if_indextoname(ifaceIdx);
+      if (options.lookupInterfaceNames !== false) {
+        if (dns_sd.kDNSServiceInterfaceIndexLocalOnly === ifaceIdx) {
+          service.networkInterface = nif.loopbackName();
+        } else if (typeof dns_sd.if_indextoname !== 'undefined' && ifaceIdx > 0) {
+          try {
+            service.networkInterface = dns_sd.if_indextoname(ifaceIdx);
 
-          interfaceNames[ifaceIdx] = service.networkInterface;
-        } catch(e) {
-          if(typeof interfaceNames[ifaceIdx] !== "undefined") {
-            service.networkInterface = interfaceNames[ifaceIdx];
-          } else {
-            self.emit('error', e);
+            interfaceNames[ifaceIdx] = service.networkInterface;
+          } catch(e) {
+            if(typeof interfaceNames[ifaceIdx] !== "undefined") {
+              service.networkInterface = interfaceNames[ifaceIdx];
+            } else {
+              self.emit('error', e);
+            }
           }
         }
       }

--- a/tests/test_browser.js
+++ b/tests/test_browser.js
@@ -70,9 +70,10 @@ module.exports["Browser"] = {
     callback();
   },
 
-  "Should not resolve interface name when disabled in options": function(test) {
+  "Should resolve interface name when lookupInterfaceNames if not given": function(test) {
     var callback = null
       , didCallIndexToName = false
+      , interfaceName = "foo"
       , serviceName = "_foo._tcp.";
 
     var mock_dns_sd = {
@@ -83,6 +84,46 @@ module.exports["Browser"] = {
       // we stub the if_indextoname method
       if_indextoname: function() {
         didCallIndexToName = true;
+        return interfaceName;
+      },
+      // and stub DNSServiceBrowse to expose a reference to the passed callback
+      DNSServiceBrowse: function(sdRef, flags, ifaceIdx, serviceType, domain, on_service_changed, context) {
+        callback = function() {
+        // pass 1 as the interface index so we don't try to find the name for loopback
+          on_service_changed(sdRef, flags, 1, dns_sd.kDNSServiceErr_NoError, serviceName, serviceType, domain, context);
+        };
+      }
+    };
+
+    // create the browser with our mock of dns_sd
+    var browser = proxyquire('../lib/browser.js', { './dns_sd': mock_dns_sd }).Browser.create(serviceName);
+    browser.on("serviceDown", function(service) {
+      // should not have called index to name
+      test.ok( didCallIndexToName );
+
+      // interface name should be undefined
+      test.equal(service.networkInterface, "foo");
+    });
+
+    // simulate MDNS events, this will trigger the serviceDown event we listen for above.
+    callback();
+  },
+
+  "Should not resolve interface name when disabled in options": function(test) {
+    var callback = null
+      , didCallIndexToName = false
+      , interfaceName = "foo"
+      , serviceName = "_foo._tcp.";
+
+    var mock_dns_sd = {
+      kDNSServiceErr_NoError: dns_sd.kDNSServiceErr_NoError,
+      kDNSServiceInterfaceIndexLocalOnly: dns_sd.kDNSServiceInterfaceIndexLocalOnly,
+      kDNSServiceFlagsAdd: dns_sd.kDNSServiceFlagsAdd,
+
+      // we stub the if_indextoname method
+      if_indextoname: function() {
+        didCallIndexToName = true;
+        return interfaceName;
       },
       // and stub DNSServiceBrowse to expose a reference to the passed callback
       DNSServiceBrowse: function(sdRef, flags, ifaceIdx, serviceType, domain, on_service_changed, context) {


### PR DESCRIPTION
Add new option to disable looking up the interface name on an event. 

Not sure, but could it be that the assertions are not working correctly?

See https://github.com/agnat/node_mdns/issues/244 for context.

