### PR TITLE
fix: github pages URL uses github.io domain, now

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -85,7 +85,7 @@ Version 0.0.3 to 0.0.4
      The strings have been replaced with a small ServiceType object. Also, older
      versions used TCP as the default protocol. The protocol is now mandatory.
      However, the new syntax is much more flexible. See user guide at
-     http://agnat.github.com/node_mdns/user_guide.html#service_types.
+     http://agnat.github.io/node_mdns/user_guide.html#service_types.
 
    - The 'info' object is now called 'service'
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 * Package: mdns
 * Description: multicast DNS service discovery
 * Installation: `npm install mdns` (see below)
-* Documentation: [mdns user guide](http://agnat.github.com/node_mdns/user_guide.html)
+* Documentation: [mdns user guide](http://agnat.github.io/node_mdns/user_guide.html)
 * License: [MIT](http://github.com/agnat/node_mdns/blob/master/LICENSE)
 * Donations: [![Flattr this git repository](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=agnat&url=https://github.com/agnat/node_mdns&title=node_mdns&tags=github&category=software)
 
@@ -67,7 +67,7 @@ In case you want to run or even publish your package using the development versi
 
 ## Documentation
 
-See the [user guide](http://agnat.github.com/node_mdns/user_guide.html).
+See the [user guide](http://agnat.github.io/node_mdns/user_guide.html).
 
 ## Contributors
 

--- a/doc/pages/user_guide.ejs
+++ b/doc/pages/user_guide.ejs
@@ -4,7 +4,7 @@
 <a class="FlattrButton" style="display:none;"
     title="mdns User Guide"
     rel="flattr;uid:agnat;category:text;"
-    href="http://agnat.github.com/node_mdns/user_guide.html">
+    href="http://agnat.github.io/node_mdns/user_guide.html">
 mdns User Guide
 </a>
 </div>

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "type": "git",
     "url": "http://github.com/agnat/node_mdns.git"
   },
-  "homepage": "http://agnat.github.com/node_mdns",
+  "homepage": "http://agnat.github.io/node_mdns",
   "bugs": {
     "url": "http://github.com/agnat/node_mdns/issues"
   },


### PR DESCRIPTION
this corrects the old and no longer functioning links to documentation
on the old `agnat.github.com` domain. github now uses `.io` TLD for
github pages, so all links (including an old link in the CHANGELOG) have
been updated to reflect this.