### PR TITLE
fix: null addresses error

### DIFF
--- a/lib/resolver_sequence_tasks.js
+++ b/lib/resolver_sequence_tasks.js
@@ -117,6 +117,9 @@ try {
       , err = cares.getaddrinfo(req, host, family, 0, false)
       ;
     req.oncomplete = function oncomplete(err, addresses) {
+        if (addresses === null) {
+          addresses = [];
+        }
         getaddrinfo_complete(err, addresses, cb);
     }
     if (err) throw errnoException(err, 'getaddrinfo', host);


### PR DESCRIPTION
browser.start() is abnormally terminate, when addresses is null. So I think replacing null with an empty array is better than terminating